### PR TITLE
Submit GCLID and first/last UTM params

### DIFF
--- a/forms.js
+++ b/forms.js
@@ -39,7 +39,7 @@ Webflow.push(function () {
 
       cookies.forEach(cookie => {
         let [name, value] = cookie.split('=').map(s => s.trim());
-        if (name.includes('utm')) {
+        if (name.includes('utm') || name.includes('gclid')) {
           utmData[name.replace('_last', '')] = decodeURIComponent(value);
         }
       });

--- a/forms.js
+++ b/forms.js
@@ -35,12 +35,12 @@ Webflow.push(function () {
 
       // Get UTM cookie data
       let cookies = document.cookie.split(';');
-      let utmCookies = {};
+      let utmData = {};
 
       cookies.forEach(cookie => {
         let [name, value] = cookie.split('=').map(s => s.trim());
         if (name.includes('utm')) {
-          utmCookies[name] = decodeURIComponent(value);
+          utmData[name.replace('_last', '')] = decodeURIComponent(value);
         }
       });
 
@@ -56,7 +56,7 @@ Webflow.push(function () {
         email: email,
         fields: obj,
         url: document.URL,
-        utm: utmCookies
+        utm: utmData
       });
 
       // Add email to local storage

--- a/forms.js
+++ b/forms.js
@@ -56,7 +56,11 @@ Webflow.push(function () {
         email: email,
         fields: obj,
         url: document.URL,
-        utm: utmData
+        context: {
+          campaign: {
+            ...utmData,
+          }
+        }
       });
 
       // Add email to local storage


### PR DESCRIPTION
## Related Issues

- Related to https://github.com/closeio/close-ui/issues/10105

## Background

Marketing would like us to track two new pieces of data: GCLID and First Touch UTM parameters.

## Description

This PR is complementary to https://github.com/closeio/close-ui/pull/10112. When we submit UTM cookies, we'll submit both first touch (`_first`) and last touch (`_last`) cookies. The _last cookies will drop their suffix, so Segment will receive values like utm_campaign_first and utm_campaign - the suffix-less cookies corresponding to the last touch is the same behavior that we have now.
