### PR TITLE
Add campaign_id to utm_names

### DIFF
--- a/utm.js
+++ b/utm.js
@@ -60,6 +60,7 @@ var utm_names = [
   'utm_content',
   'utm_term',
   'gclid',
+  'campaign_id'
 ];
 
 function getLastTouchCookie(name) {


### PR DESCRIPTION
This PR adds `campaign_id` to the `utm_names` variable in `utm.js`. See: https://github.com/closeio/close-ui/issues/11527