### PR TITLE
Rename utm param

### DIFF
--- a/utm.js
+++ b/utm.js
@@ -60,7 +60,7 @@ var utm_names = [
   'utm_content',
   'utm_term',
   'gclid',
-  'campaign_id'
+  'cid',
 ];
 
 function getLastTouchCookie(name) {


### PR DESCRIPTION
## Related Issues
<!-- Reference any related GitHub issues. For example, "Closes #1234" if your PR closes that issue -->

- Part of https://github.com/closeio/close-ui/issues/11527 (issue has been edited to include correct id)

## Background

The new UTM param we need is `cid`, not `campaign_id`.

## Description

Updates `campaign_id` to `cid`.
