### PR TITLE
Add support for Bing, Meta, and LinkedIn UTM sources

### DIFF
--- a/utm.js
+++ b/utm.js
@@ -61,6 +61,9 @@ var utm_names = [
   'utm_term',
   'gclid',
   'cid',
+  'msclkid',
+  'fbclid',
+  'li_fat_id',
 ];
 
 function getLastTouchCookie(name) {


### PR DESCRIPTION
## Related Issues

Should release with https://github.com/closeio/closeio/pull/39618
Should release with https://github.com/closeio/close-ui/pull/12027

## Background
We want to add Bing, Meta, and LinkedIn UTM sources. This changeset fulfills requirements of the `webflow-js` codebase for https://github.com/closeio/close-ui/issues/12019 according to [the relevant docs](https://docs-add-utm-documentation.previews.close.com/guides/adding-utm-properties#webflow-js-the-code-for-the-wwwclosecom-site).

## Description
This changeset adds the necessary code for adding Bing, Meta, and LinkedIn as UTM sources.