### PR TITLE
Update Segment analytics identify method

### DIFF
--- a/forms.js
+++ b/forms.js
@@ -70,7 +70,7 @@ Webflow.push(function () {
 
         // Send data to Segment
         try {
-            analytics.identify(analytics.user().anonymousId(), {
+            analytics.identify({
                 email: email,
                 last_form_submission_confirmation_url: obj["last_form_submission_confirmation_url"],
                 last_form_submission_name: $form.get(0).attributes[2].nodeValue,

--- a/forms/demo.js
+++ b/forms/demo.js
@@ -88,7 +88,7 @@ Webflow.push(function () {
 
                 // Send data to Segment
                 try {
-                    analytics.identify(analytics.user().anonymousId(), {
+                    analytics.identify({
                         email: email,
                         last_form_submission_confirmation_url: obj["last_form_submission_confirmation_url"],
                         last_form_submission_name: $form.get(0).attributes[2].nodeValue,

--- a/modals.js
+++ b/modals.js
@@ -48,7 +48,6 @@ function showModal() {
             localStorage.setItem('trialModalShown', 'true');
             
             // Send data to Segment
-            analytics.identify(analytics.user().anonymousId());
             analytics.track('Popup Viewed', {
                 popup_name: 'Start Free Trial',
                 url: document.URL


### PR DESCRIPTION
As per Segment's [docs](https://segment.com/docs/connections/spec/best-practices-identify/#soft-user-registration), we don't need to pass anonymous id to the `identify` as it [screws up the attribution](https://segment.com/docs/connections/spec/best-practices-identify/#id-expiration-and-overwriting).

![image](https://github.com/user-attachments/assets/65a5d6be-c5dd-4f18-8021-84f3e46ea953)
